### PR TITLE
build with gcc 13 and avr-libc 2.1

### DIFF
--- a/thermidity-avr/Makefile
+++ b/thermidity-avr/Makefile
@@ -28,7 +28,7 @@ CFLAGS += -g -ggdb
 CFLAGS += -ffunction-sections -fdata-sections -Wl,--gc-sections -Wl,--relax
 CFLAGS += -std=gnu99
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
-CFLAGS += --param=min-pagesize=0
+# CFLAGS += --param=min-pagesize=0
 
 TARGET = $(strip $(basename $(MAIN)))
 SRC += $(TARGET).c

--- a/thermidity-avr/Makefile
+++ b/thermidity-avr/Makefile
@@ -27,6 +27,8 @@ CFLAGS += -Wall -Wstrict-prototypes
 CFLAGS += -g -ggdb
 CFLAGS += -ffunction-sections -fdata-sections -Wl,--gc-sections -Wl,--relax
 CFLAGS += -std=gnu99
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
+CFLAGS += --param=min-pagesize=0
 
 TARGET = $(strip $(basename $(MAIN)))
 SRC += $(TARGET).c
@@ -50,7 +52,7 @@ eeprom: $(TARGET).eeprom
 	$(OBJDUMP) -S $< > $@
  
 size:  $(TARGET).elf
-	$(AVRSIZE) -C --mcu=$(MCU) $(TARGET).elf
+	$(AVRSIZE) -G $(TARGET).elf
 
 clean:
 	rm -f $(TARGET).elf $(TARGET).hex $(TARGET).obj \

--- a/thermidity-avr/nbproject/configurations.xml
+++ b/thermidity-avr/nbproject/configurations.xml
@@ -31,7 +31,7 @@
   <confs>
     <conf name="Default" type="0">
       <toolsSet>
-        <compilerSet>AVR|GNU</compilerSet>
+        <compilerSet>AVR2.1-GCC13.2|GNU</compilerSet>
         <dependencyChecking>false</dependencyChecking>
         <rebuildPropChanged>false</rebuildPropChanged>
       </toolsSet>


### PR DESCRIPTION
- set --param=min-pagesize=0 to fix false warning "array subscript [0] is outside array bounds"
- adjust 'size' target