### PR TITLE
remove unnecessary delays in display initialization

### DIFF
--- a/thermidity-avr/eink.c
+++ b/thermidity-avr/eink.c
@@ -52,10 +52,10 @@ void displayData(uint8_t data) {
 
 void initDisplay(bool fast) {
     // 1. Power On
-    // VCI already supplied - could supply by MCU output pin?
     // - Supply VCI
     // - Wait 10ms
-    _delay_ms(10);
+    // VCI already supplied, no need to wait
+    // _delay_ms(10);
     
     displaySel();
 
@@ -65,7 +65,7 @@ void initDisplay(bool fast) {
 
     // - HW Reset
     hwReset();
-    _delay_ms(100);
+    // _delay_ms(100);
     waitBusy();
 
     // - SW Reset by Command 0x12


### PR DESCRIPTION
- no need to wait 10ms since VCI already supplied, display is in deep sleep mode
- no need to wait 100ms after hardware eset (waiting for busy) before software reset

=> might contribute to a tiny reduction of power consumption