### PR TITLE
Let watchdog wake up MCU only every 8 instead of 1 seconds, saving some power

### DIFF
--- a/thermidity-avr/thermidity.c
+++ b/thermidity-avr/thermidity.c
@@ -33,18 +33,19 @@
 #include "usart.h"
 
 /* Measure and average temperature and relative humidity every ~32 seconds */
-#define MEASURE_SECS    4 // should be a power of 2 to avoid division 
+#define MEASURE_INTS    4 // should be a power of 2 to avoid division 
 /* Display should not be updated more frequently than once every 180 seconds */
-#define DISP_UPD_SECS   36
+#define DISP_UPD_INTS   36
 /* Number of fast updates until a full update is done to avoid ghosting */
 #define DISP_MAX_FAST   9
 
-static volatile uint8_t secs = 36;
+/* 1 int = 8 seconds */
+static volatile uint8_t ints = DISP_UPD_INTS;
 
 static uint8_t updates = DISP_MAX_FAST + 1;
 
 ISR(WDT_vect) {
-    secs++;
+    ints++;
 }
 
 EMPTY_INTERRUPT(ADC_vect);
@@ -111,7 +112,7 @@ static void initWatchdog(void) {
     wdt_reset();
     // watchdog change enable
     WDTCSR |= (1 << WDCE) | (1 << WDE);
-    // enable interrupt, disable system reset, bark every 1 seconds
+    // enable interrupt, disable system reset, bark every 8 seconds
     WDTCSR = (1 << WDIE) | (0 << WDE) | (1 << WDP3) | (1 << WDP0);
 }
 
@@ -199,11 +200,9 @@ int main(void) {
 
     // enable global interrupts
     sei();
-    
-    // _delay_ms(1000);
 
     while (true) {
-        if (secs % MEASURE_SECS == 0) {
+        if (ints % MEASURE_INTS == 0) {
             powerOnSensors();
             // give the humidity sensor time to settle
             _delay_ms(100);
@@ -212,8 +211,8 @@ int main(void) {
             disableADC();
             powerOffSensors();
 
-            if (secs >= DISP_UPD_SECS) {
-                secs = 0;
+            if (ints >= DISP_UPD_INTS) {
+                ints = 0;
 
                 // measured battery voltage is /5 by voltage divider
                 if (getMVBat() < BAT_LOW / 5) {


### PR DESCRIPTION
- set watchdog to bark every 8 seconds
- counter can now be 8 instead of 16 bit - ATOMIC_BLOCK not needed
- adjust constant and variable names
- saves about 4uA in average power consumption