### PR TITLE
More optimizations

### DIFF
--- a/thermidity-avr/bitmaps.h
+++ b/thermidity-avr/bitmaps.h
@@ -20,14 +20,17 @@
 #define BAT_88PCT   7
 #define BAT_100PCT  8
 
+typedef uint8_t width_t;
+typedef uint8_t height_t;
+
 /**
  * A bitmap with its width and height, and data.
  */
 typedef struct {
     /** Width of the bitmap, must be a multiple of 8. */
-    const uint16_t width;
+    const width_t width;
     /** Height of the bitmap, must be a multiple of 8. */
-    const uint16_t height;
+    const height_t height;
     /** The actual bitmap. */
     const __flash uint8_t *bitmap;
 } Bitmap;

--- a/thermidity-avr/display.c
+++ b/thermidity-avr/display.c
@@ -77,17 +77,10 @@ static void bufferBitmap(uint8_t row, uint16_t col,
         }
 
         // rotate 8 x 8 pixel
-        // uint16_t m = i / 8 * 8;
-        // We have i - m = i - i/8 * 8 = i & 7, and this mask
-        // does not depend on r and can be computed before the loop.
-        uint8_t mask = 1u << (7 - (i & 7));
-        // No need to loop if `next' is empty.
-        for (uint8_t r = 0; next; r++) {
-            // `next' may be consumed and is not used after this loop.
-            if (next & (1u << 7)) {
-                rotated[r] |= mask;
-            }
-            next <<= 1;
+        uint16_t m = i / 8 * 8;
+        for (uint8_t r = 0; r < 8; r++) {
+            uint8_t bit = (next & (1 << (7 - r))) ? 1 : 0;
+            rotated[r] |= bit << (7 - i + m);
         }
 
         // buffer 8 x 8 rotated pixel

--- a/thermidity-avr/display.c
+++ b/thermidity-avr/display.c
@@ -142,7 +142,7 @@ uint8_t writeBitmap(uint16_t row, uint16_t col, uint16_t index) {
     return bitmap->width;
 }
 
-uint8_t writeGlyph(uint16_t row, uint16_t col, const __flash Font *font, uint16_t code) {
+uint8_t writeGlyph(uint16_t row, uint16_t col, const __flash Font *font, code_t code) {
     const __flash Glyph *glyph = getGlyphAddress(font, code);
     bufferBitmap(row, col, glyph->bitmap, glyph->width, font->height);
     
@@ -159,7 +159,7 @@ void writeString(uint16_t row, uint16_t col, const __flash Font *font, char *str
             // multibyte, add 64 to get code point
             offset = 64;
         } else {
-            uint16_t code = c + offset;
+            code_t code = c + offset;
             col += writeGlyph(row, col, font, code);
             offset = 0;
         }

--- a/thermidity-avr/display.c
+++ b/thermidity-avr/display.c
@@ -77,10 +77,17 @@ static void bufferBitmap(uint8_t row, uint16_t col,
         }
 
         // rotate 8 x 8 pixel
-        uint16_t m = i / 8 * 8;
-        for (uint8_t r = 0; r < 8; r++) {
-            uint8_t bit = (next & (1 << (7 - r))) ? 1 : 0;
-            rotated[r] |= bit << (7 - i + m);
+        // uint16_t m = i / 8 * 8;
+        // We have i - m = i - i/8 * 8 = i & 7, and this mask
+        // does not depend on r and can be computed before the loop.
+        uint8_t mask = 1u << (7 - (i & 7));
+        // No need to loop if `next' is empty.
+        for (uint8_t r = 0; next; r++) {
+            // `next' may be consumed and is not used after this loop.
+            if (next & (1u << 7)) {
+                rotated[r] |= mask;
+            }
+            next <<= 1;
         }
 
         // buffer 8 x 8 rotated pixel

--- a/thermidity-avr/display.c
+++ b/thermidity-avr/display.c
@@ -8,6 +8,8 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdbool.h>
+#include "display.h"
 #include "unifont.h"
 #include "dejavu.h"
 #include "bitmaps.h"
@@ -25,7 +27,7 @@
  * @param byte
  */
 static void bufferByte(uint16_t index, uint16_t index_mod_height, 
-                       uint16_t *address, uint16_t height, uint8_t byte) {
+                       uint16_t *address, height_t height, uint8_t byte) {
     // if (index % height == 0) {
     if (index_mod_height == 0) {
         if (index > 0) {
@@ -49,9 +51,9 @@ static void bufferByte(uint16_t index, uint16_t index_mod_height,
  * @param width
  * @param height
  */
-static void bufferBitmap(uint8_t row, uint16_t col,
+static void bufferBitmap(row_t row, col_t col,
                          const __flash uint8_t *bitmap,
-                         uint16_t width, uint16_t height) {
+                         width_t width, height_t height) {
     uint16_t size = width * height / 8;
     uint16_t origin = DISPLAY_WIDTH * DISPLAY_H_BYTES + row - col * DISPLAY_H_BYTES;
 
@@ -128,21 +130,21 @@ void setFrame(uint8_t byte) {
     }
 }
 
-uint8_t writeBitmap(uint16_t row, uint16_t col, uint16_t index) {
+width_t writeBitmap(row_t row, col_t col, uint16_t index) {
     const __flash Bitmap *bitmap = &bitmaps[index];
     bufferBitmap (row, col, bitmap->bitmap, bitmap->width, bitmap->height);
     
     return bitmap->width;
 }
 
-uint8_t writeGlyph(uint16_t row, uint16_t col, const __flash Font *font, code_t code) {
+width_t writeGlyph(row_t row, col_t col, const __flash Font *font, code_t code) {
     const __flash Glyph *glyph = getGlyphAddress(font, code);
     bufferBitmap(row, col, glyph->bitmap, glyph->width, font->height);
     
     return glyph->width;
 }
 
-void writeString(uint16_t row, uint16_t col, const __flash Font *font, char *string) {
+void writeString(row_t row, col_t col, const __flash Font *font, char *string) {
     uint8_t offset = 0;
     for (; *string != '\0'; string++) {
         uint8_t c = (uint8_t) *string;

--- a/thermidity-avr/display.h
+++ b/thermidity-avr/display.h
@@ -41,7 +41,7 @@ uint8_t writeBitmap(uint16_t row, uint16_t col, uint16_t index);
  * @param code
  * @return glyph width
  */
-uint8_t writeChar(uint16_t row, uint16_t col, Font font, uint16_t code);
+uint8_t writeChar(uint16_t row, uint16_t col, Font font, code_t code);
 
 /**
  * Writes the given string with the given font to the given row and column.

--- a/thermidity-avr/display.h
+++ b/thermidity-avr/display.h
@@ -8,7 +8,11 @@
 #ifndef DISPLAY_H
 #define DISPLAY_H
 
+#include "bitmaps.h"
 #include "font.h"
+
+typedef uint8_t row_t;
+typedef uint8_t col_t;
 
 /**
  * Copies image data from SRAM to display.
@@ -30,7 +34,7 @@ void setFrame(uint8_t byte);
  * @param index
  * @return bitmap width
  */
-uint8_t writeBitmap(uint16_t row, uint16_t col, uint16_t index);
+width_t writeBitmap(row_t row, col_t col, uint16_t index);
 
 /**
  * Writes the glyph with the given pseudo UTF-8 code point with the given
@@ -41,7 +45,7 @@ uint8_t writeBitmap(uint16_t row, uint16_t col, uint16_t index);
  * @param code
  * @return glyph width
  */
-uint8_t writeChar(uint16_t row, uint16_t col, Font font, code_t code);
+width_t writeGlyph(row_t row, col_t col, const __flash Font *font, code_t code);
 
 /**
  * Writes the given string with the given font to the given row and column.
@@ -50,7 +54,7 @@ uint8_t writeChar(uint16_t row, uint16_t col, Font font, code_t code);
  * @param font
  * @param string
  */
-void writeString(uint16_t row, uint16_t col, const __flash Font *font, char *string);
+void writeString(row_t row, col_t col, const __flash Font *font, char *string);
 
 /**
  * Initializes the display, resets the address counter, copys image data from 

--- a/thermidity-avr/font.c
+++ b/thermidity-avr/font.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include "font.h"
 
-const __flash Glyph* getGlyphAddress(const __flash Font *font, uint16_t code) {
+const __flash Glyph* getGlyphAddress(const __flash Font *font, code_t code) {
     
     // https://en.wikipedia.org/wiki/Binary_search_algorithm
     int16_t l = 0;

--- a/thermidity-avr/font.h
+++ b/thermidity-avr/font.h
@@ -8,12 +8,14 @@
 #ifndef FONT_H
 #define FONT_H
 
+typedef uint8_t code_t;
+
 /**
  * A glyph with its pseudo UTF-8 code point, width and bitmap.
  */
 typedef struct {
     /** Pseudo UTF-8 code point of the glyph. */
-    const uint16_t code;
+    const code_t code;
     /** Width of the glyph. */
     const uint8_t width;
     /** Bitmap of the glyph. */
@@ -41,6 +43,6 @@ typedef struct {
  * @param code
  * @return Glyph
  */
-const __flash Glyph* getGlyphAddress(const __flash Font *font, uint16_t code);
+const __flash Glyph* getGlyphAddress(const __flash Font *font, code_t code);
 
 #endif /* FONT_H */

--- a/thermidity-avr/sram.c
+++ b/thermidity-avr/sram.c
@@ -20,19 +20,17 @@ void sramWrite(uint16_t address, uint8_t data) {
     sramDes();
 }
 
-size_t sramWriteString(uint16_t startAddress, char *data) {
-    size_t length = strlen(data);
+size_t sramWriteString(uint16_t address, const char *data) {
     size_t written = 0;
-    for (size_t i = 0; i < length; i++) {
-        uint16_t address = startAddress + i;
+    for (; address <= SRAM_HIGH; ++address) {
         char c = *data++;
-        sramWrite(address, c);
-        written++;
-        if (address == SRAM_HIGH) {
+        if (c == 0) {
             break;
         }
+        sramWrite(address, c);
+        written++;
     }
-
+    
     return written;
 }
 
@@ -47,13 +45,12 @@ uint8_t sramRead(uint16_t address) {
     return read;
 }
 
-void sramReadString(uint16_t startAddress, char *buf, size_t length) {
+void sramReadString(uint16_t address, char *buf, size_t length) {
     for (size_t i = 0; i < length - 1; i++) {
-        uint16_t address = startAddress + i;
-        buf[i] = sramRead(address);
-        if (address == SRAM_HIGH) {
+        if (address > SRAM_HIGH) {
             break;
         }
+        buf[i] = sramRead(address++);
     }
     buf[length - 1] = '\0';
 }

--- a/thermidity-avr/sram.h
+++ b/thermidity-avr/sram.h
@@ -30,11 +30,11 @@ void sramWrite(uint16_t address, uint8_t data);
  * Writes the given string starting at the given address, never beyond
  * the highest memory address, and returns the number of bytes actually
  * written.
- * @param startAddress
+ * @param address
  * @param data
  * @return number of bytes written
  */
-size_t sramWriteString(uint16_t startAddress, char *data);
+size_t sramWriteString(uint16_t address, const char *data);
 
 /**
  * Reads the byte at the given address and returns it.
@@ -47,11 +47,11 @@ uint8_t sramRead(uint16_t address);
  * Reads length - 1 bytes starting at the given address, never beyond 
  * the highest memory address, into the given buffer and adds a trailing 
  * null terminator.
- * @param startAddress
+ * @param address
  * @param string
  * @param length
  */
-void sramReadString(uint16_t startAddress, char *string, size_t length);
+void sramReadString(uint16_t address, char *string, size_t length);
 
 /**
  * Writes the given status.

--- a/thermidity-avr/thermidity.c
+++ b/thermidity-avr/thermidity.c
@@ -200,6 +200,9 @@ int main(void) {
 
     // enable global interrupts
     sei();
+    
+    // delay initial display update after power on
+    _delay_ms(1000);
 
     while (true) {
         if (ints % MEASURE_INTS == 0) {


### PR DESCRIPTION
- optimize writing strings to and reading strings from SRAM
- delay initial display update after power on
- use 'typedef uint8_t code_t' for char codes instead of uint16_t etc.